### PR TITLE
프론트엔드 CI 워크플로우 추가

### DIFF
--- a/.github/workflows/frontend_ci.yaml
+++ b/.github/workflows/frontend_ci.yaml
@@ -1,0 +1,62 @@
+name: frontend_ci
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "front/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ./frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+      - name: Cache dependencies
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: 'front/node_modules'
+          key: ${{ runner.os }}-node-${{ hashFiles('front/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Run test
+        run: npm run test
+
+  build:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ./front
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+      - name: Cache dependencies
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: front/node_modules
+          key: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('front/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('front/package-lock.json') }}
+      - name: Install Dependencies
+        if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        run: npm ci
+      - name: Run build
+        run: npm run build


### PR DESCRIPTION
프론트엔드 코드에 대한 지속적 통합(CI) 워크플로우를 추가했습니다. 이 워크플로우는 pull request가 main 브랜치로 들어올 때 실행됩니다.

주요 변경사항:
1. 프론트엔드 CI 워크플로우 파일(.github/workflows/frontend_ci.yaml) 추가
2. pull request가 main 브랜치로 들어올 때 실행되도록 설정
3. 테스트 및 빌드 작업 정의
4. Node.js 설정 및 의존성 캐싱 추가
5. npm을 사용한 의존성 설치 및 테스트/빌드 실행