### PR TITLE
서비스 브랜딩 텍스트 통일 및 이벤트 문구 개선

### DIFF
--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -9,7 +9,7 @@ const poppins = Poppins({
 })
 
 export const metadata: Metadata = {
-  title: "Job-Play",
+  title: "Job Play",
   description: "지원자에게 이력서를 받아서 매칭해주는 서비스 취업 컨설팅",
 };
 
@@ -20,9 +20,7 @@ export default function RootLayout({
 }>) {
   return (
       <html lang="en">
-      <body
-          className={`${poppins.variable} font-poppins antialiased`}
-      >
+      <body className={`${poppins.variable} font-poppins antialiased`}>
       {children}
       </body>
       </html>

--- a/front/components/common/Header.tsx
+++ b/front/components/common/Header.tsx
@@ -6,7 +6,7 @@ export const Header = () => {
   return (
     <header className="border-b border-gray-100 bg-white">
       <div className="container mx-auto px-4 py-3 text-center">
-        <h1 className="text-sm font-medium text-gray-900">JOB PLPY</h1>
+        <h1 className="text-sm font-medium text-gray-900">Job Play</h1>
       </div>
     </header>
   );

--- a/front/components/common/HeaderSection.tsx
+++ b/front/components/common/HeaderSection.tsx
@@ -8,9 +8,9 @@ export const HeaderSection = () => {
       </div>
       <h1 className="text-2xl font-bold text-blue-600">취업 축하 이벤트!</h1>
       <p className="text-sm text-gray-600">
-        당첨하시면 꼭 제대 취업 상금 3개월 이후
-        <br />
-        지급되게끔 500원씩을 지급됩니다.
+        잡플레이를 통해 취업 성공후 3개월이
+        <br/>
+        지나면 취업축하금 50만원을 지급해 드립니다.
       </p>
     </div>
   );


### PR DESCRIPTION
브랜드 일관성을 위해 서비스명과 관련 텍스트를 수정하고, 취업 축하 이벤트 문구를 명확하게 개선했습니다.

주요 변경사항:
1. 메타데이터 타이틀을 "Job-Play"에서 "Job Play"로 일관성 있게 변경
2. 헤더 컴포넌트의 서비스명 오타 수정 ("JOB PLPY" → "Job Play")
3. HeaderSection 컴포넌트의 취업 축하 이벤트 문구를 보다 명확하고 전문적으로 개선
4. 레이아웃 관련 코드의 불필요한 들여쓰기 정리